### PR TITLE
Add a visitor generating point-edge-point graph

### DIFF
--- a/astmonkey/visitors.py
+++ b/astmonkey/visitors.py
@@ -655,3 +655,24 @@ class SourceGeneratorNodeVisitor(ast.NodeVisitor):
         if node.msg:
             self.write(', ')
             self.visit(node.msg)
+
+
+class EdgeGraphNodeVisitor(GraphNodeVisitor):
+
+    """Simple point-edge-point graphviz representation of the AST."""
+
+    def __init__(self):
+        super(self.__class__, self).__init__()
+        self.graph.set_node_defaults(shape='point')
+
+    def _dot_graph_kwargs(self):
+        return {}
+
+    def _dot_node_kwargs(self, node):
+        return {}
+
+    def _dot_edge(self, node):
+        return pydot.Edge(id(node.parent), id(node))
+
+    def _dot_node(self, node):
+        return pydot.Node(id(node), **self._dot_node_kwargs(node))


### PR DESCRIPTION
I was looking for a tool to illustrate relative complexity of a python program before and after refactoring. Attached visitor extends `GraphNodeVisitor` to draw only points and edges of an AST and giving a basic view of complexity. By example, running the following PoC on files from this project yields:

```
#!/usr/bin/env python
# ast_to_epe_png.py

import ast
import sys, os
from astmonkey import visitors, transformers

filename = sys.argv[1]

node = ast.parse(open(filename).read())
node = transformers.ParentNodeTransformer().visit(node)
visitor = visitors.EdgeGraphNodeVisitor()
visitor.visit(node)
visitor.graph.write(filename + '.dot')
os.system('sfdp -Tpng -o {} {}'.format(filename + '.png', filename + '.dot'))
```

**transformers.py**
![transformers py](https://cloud.githubusercontent.com/assets/1587140/7018469/b3b156cc-dcb9-11e4-80e6-c0c1a1dad998.png)
**utils.py**
![utils py](https://cloud.githubusercontent.com/assets/1587140/7018480/dafee10e-dcb9-11e4-82d1-39d438875893.png)
**visitors.py**
![visitors py](https://cloud.githubusercontent.com/assets/1587140/7018486/e6cc03c2-dcb9-11e4-998a-ad00e7c0bebd.png)
